### PR TITLE
Set staticPretty's default configuration value to the opposite of brunch's config.optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class PugCompiler {
         doctype: 'html',
         basedir: defaultBasedir,
         staticBasedir: sysPath.join(defaultBasedir, 'assets'),
-        staticPretty: true,
+        staticPretty: !brunchConf.optimize,
         inlineRuntimeFunctions: false,
         compileDebug: !brunchConf.optimize,
         sourceMap: !!brunchConf.sourceMaps


### PR DESCRIPTION
I'm not really fixing a bug, so please consider this to be a feature request! I was debating whether or not I should've made this as an issue first, but I figured a pull request would be less work for you, right? Um, if you don't like it, feel free to say so and I'll close this. 😄

---

I noticed that `staticPretty` was being set to true regardless of what mode I was running brunch in, so I would end up having to manually set it to `false` and then back again every time I wanted to build my project. I was thinking that since `optimize` minifies all my other files anyways, it would be convenient to have the output from this plugin change based on that as well.